### PR TITLE
Implemented loop counter for "Every" trigger

### DIFF
--- a/aioclock/triggers.py
+++ b/aioclock/triggers.py
@@ -68,12 +68,14 @@ class OnShutDown(Once):
 
 class Every(BaseTrigger):
     type_: Literal[Triggers.EVERY] = Triggers.EVERY
+    triggered_counter: int = 0
 
     seconds: Union[PositiveNumber, None] = None
     minutes: Union[PositiveNumber, None] = None
     hours: Union[PositiveNumber, None] = None
     days: Union[PositiveNumber, None] = None
     weeks: Union[PositiveNumber, None] = None
+    counter: Union[int, None] = None
 
     @model_validator(mode="after")
     def validate_time_units(self):
@@ -103,8 +105,12 @@ class Every(BaseTrigger):
         return result
 
     async def trigger_next(self) -> None:
+        self.triggered_counter += 1
         await asyncio.sleep(self.to_seconds)
         return
+
+    def should_trigger(self) -> bool:
+        return True if self.counter is None else self.counter > self.triggered_counter
 
 
 WEEK_TO_SECOND = 604800

--- a/aioclock/triggers.py
+++ b/aioclock/triggers.py
@@ -1,13 +1,13 @@
 import asyncio
-import zoneinfo
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from datetime import datetime, timedelta
 from typing import Literal, Union
 
+import zoneinfo
 from pydantic import BaseModel, model_validator
 
-from aioclock.types import EveryT, HourT, MinuteT, SecondT, Triggers
+from aioclock.types import EveryT, HourT, MinuteT, PositiveNumber, SecondT, Triggers
 
 
 class BaseTrigger(BaseModel, ABC):
@@ -69,11 +69,11 @@ class OnShutDown(Once):
 class Every(BaseTrigger):
     type_: Literal[Triggers.EVERY] = Triggers.EVERY
 
-    seconds: Union[int, float, None] = None
-    minutes: Union[int, float, None] = None
-    hours: Union[int, float, None] = None
-    days: Union[int, float, None] = None
-    weeks: Union[int, float, None] = None
+    seconds: Union[PositiveNumber, None] = None
+    minutes: Union[PositiveNumber, None] = None
+    hours: Union[PositiveNumber, None] = None
+    days: Union[PositiveNumber, None] = None
+    weeks: Union[PositiveNumber, None] = None
 
     @model_validator(mode="after")
     def validate_time_units(self):

--- a/aioclock/types.py
+++ b/aioclock/types.py
@@ -1,5 +1,5 @@
 from enum import auto
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Union
 
 from annotated_types import Interval
 
@@ -19,6 +19,8 @@ EveryT = Literal[
 SecondT = Annotated[int, Interval(ge=0, le=59)]
 MinuteT = Annotated[int, Interval(ge=0, le=59)]
 HourT = Annotated[int, Interval(ge=0, le=24)]
+
+PositiveNumber = Annotated[Union[int, float], Interval(ge=0)]
 
 
 class Triggers(StrEnum):


### PR DESCRIPTION
If pass any negative number to parameters of `Every` trigger, it will go to an infinity loop without any sleep time!
So I think it's better to accept only **positive** numbers as arguments.