### PR TITLE
Bring timeout support for scheduled tasks in aioclock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/aioclock/api.py
+++ b/aioclock/api.py
@@ -5,10 +5,13 @@ This module could be very useful if you intend to use aioclock in a web applicat
 Other tools and extension are written from this tool.
 
 !!! danger "Note when writing to aioclock API and changing its state."
-    Right now the state of AioClock instance is on the memory level, so if you write an API and change a task's trigger time, it will not persist.
-    In future we might store the state of AioClock instance in a database, so that it always remains same.
-    But this is a bit tricky and implicit because then your code gets ignored and database is preferred over the codebase.
-    For now you may consider it as a way to change something without redeploying the application, but it is not very recommended to write.
+    Right now the state of AioClock instance is on the memory level,
+    so if you write an API and change a task's trigger time, it will not persist.
+    In the future, we might store the state of AioClock instance in a database, so that it always remains same.
+    But this is a bit tricky and implicit because then your code gets ignored
+    and database is preferred over the codebase.
+    For now, you may consider it as a way to change something without redeploying the application,
+    but it is not very recommended to write.
 """
 
 import sys
@@ -37,8 +40,9 @@ class TaskMetadata(BaseModel):
 
     Attributes:
         id: UUID: Task ID that is unique for each task, and changes every time you run the aioclock app.
-            In future we might store task ID in a database, so that it always remains same.
-        trigger: Union[TriggerT, Any]: Trigger that is used to run the task, type is also any to ease implementing new triggers.
+            In the future, we might store task ID in a database, so that it always remains same.
+        trigger: Union[TriggerT, Any]: Trigger that is used to run the task,
+            type is also any to ease implementing new triggers.
         task_name: str: Name of the task function.
     """
 
@@ -54,7 +58,7 @@ async def run_specific_task(task_id: UUID, app: AioClock):
 
     params:
         task_id: Task ID that is unique for each task, and changes every time you run the aioclock app.
-            In future we might store task ID in a database, so that it always remains same.
+            In the future, we might store task ID in a database, so that it always remains same.
         app: AioClock instance to run the task from.
 
     Example:
@@ -114,7 +118,7 @@ async def run_with_injected_deps(func: Callable[P, Awaitable[T]]) -> T:
 async def get_metadata_of_all_tasks(app: AioClock) -> list[TaskMetadata]:
     """Get metadata of all tasks that are included in the AioClock instance.
 
-    This function can be used to mutate the `TaskMetadata` object, i.e to change the trigger of a task.
+    This function can be used to mutate the `TaskMetadata` object, i.e. to change the trigger of a task.
     But for now it is yet not recommended to do this, as you might experience some unexpected behavior.
     But in next versions, I'd like to make it more stable and reliable on mutating the data.
 

--- a/aioclock/app.py
+++ b/aioclock/app.py
@@ -2,7 +2,7 @@
 To initialize the AioClock instance, you need to import the AioClock class from the aioclock module.
 AioClock class represent the aioclock, and handle the tasks and groups that will be run by the aioclock.
 
-Another way to modulize your code is to use `Group` which is kinda the same idea as router in web frameworks.
+Another way to modularize your code is to use `Group` which is kinda the same idea as router in web frameworks.
 """
 
 from __future__ import annotations
@@ -76,7 +76,7 @@ class AioClock:
     ## Lifespan
 
     You can define this startup and shutdown logic using the lifespan parameter of the AioClock instance.
-    It should be as an  AsyncContextManager which get AioClock application as arguement.
+    It should be as an  AsyncContextManager which get AioClock application as argument.
     You can find the example below.
 
     Example:
@@ -107,15 +107,16 @@ class AioClock:
 
     Here we are simulating the expensive startup operation of loading the model by putting the (fake)
     model function in the dictionary with machine learning models before the yield.
-    This code will be executed before the application starts operationg, during the startup.
+    This code will be executed before the application starts operating, during the startup.
 
     And then, right after the yield, we unload the model.
     This code will be executed after the application finishes handling requests, right before the shutdown.
     This could, for example, release resources like memory, a GPU or some database connection.
 
-    It would also happen when you're stopping your application gracefully, for example, when you're shutting down your container.
+    It would also happen when you're stopping your application gracefully,
+    for example, when you're shutting down your container.
 
-    Lifespan could also be synchronus context manager. Check the example below.
+    Lifespan could also be synchronous context manager. Check the example below.
 
 
     Example:
@@ -163,8 +164,8 @@ class AioClock:
             limiter:
                 Anyio CapacityLimiter. capacity limiter to use to limit the total amount of threads running
                 Limiter that will be used to limit the number of tasks that are running at the same time.
-                If not provided, it will fallback to the default limiter set on Application level.
-                If no limiter is set on Application level, it will fallback to the default limiter set by AnyIO.
+                If not provided, it will fall back to the default limiter set on Application level.
+                If no limiter is set on Application level, it will fall back to the default limiter set by AnyIO.
 
         """
         self._groups: list[Group] = []

--- a/aioclock/app.py
+++ b/aioclock/app.py
@@ -236,7 +236,7 @@ class AioClock:
         self._groups.append(group)
         return None
 
-    def task(self, *, trigger: BaseTrigger, timeout: float | None = None):
+    def task(self, *, trigger: BaseTrigger, timeout: Optional[float] = None):
         """
         Decorator to add a task to the AioClock instance.
         If decorated function is sync, aioclock will run it in a thread pool executor, using AnyIO.

--- a/aioclock/app.py
+++ b/aioclock/app.py
@@ -236,17 +236,22 @@ class AioClock:
         self._groups.append(group)
         return None
 
-    def task(self, *, trigger: BaseTrigger):
+    def task(self, *, trigger: BaseTrigger, timeout: float | None = None):
         """
         Decorator to add a task to the AioClock instance.
         If decorated function is sync, aioclock will run it in a thread pool executor, using AnyIO.
         But if you try to run the decorated function, it will run in the same thread, blocking the event loop.
         It is intended to not change all your `sync functions` to coroutine functions,
-            and they can be used outside of aioclock, if needed.
+            and they can be used outside aioclock, if needed.
 
         params:
             trigger: BaseTrigger
                 Trigger that will trigger the task to be running.
+
+            timeout: float | None (defaults to None)
+                Set a timeout for the task.
+                If the task completion took longer than timeout,
+                it will be cancelled and a `TaskTimeoutError` be raised by the Application.
 
         Example:
             ```python
@@ -259,11 +264,23 @@ class AioClock:
             async def main():
                 print("Hello World")
             ```
+
+        Example:
+            ```python
+
+            from aioclock import AioClock, Once
+
+            app = AioClock()
+
+            @app.task(trigger=Once(), timeout=3)
+            async def main():
+                await some_io_task()
+            ```
         """
 
         def decorator(func):
             @wraps(func)
-            async def wrapped_funciton(*args, **kwargs):
+            async def wrapped_function(*args, **kwargs):
                 if asyncio.iscoroutinefunction(func):
                     return await func(*args, **kwargs)
                 else:  # run in threadpool to make sure it's not blocking the event loop
@@ -271,19 +288,12 @@ class AioClock:
 
             self._app_tasks.append(
                 Task(
-                    func=inject(wrapped_funciton, dependency_overrides_provider=get_provider()),
+                    func=inject(wrapped_function, dependency_overrides_provider=get_provider()),
                     trigger=trigger,
+                    timeout=timeout,
                 )
             )
-            if asyncio.iscoroutinefunction(func):
-                return wrapped_funciton
-            else:
-
-                @wraps(func)
-                def wrapper(*args, **kwargs):
-                    return func(*args, **kwargs)
-
-                return wrapper
+            return wrapped_function
 
         return decorator
 

--- a/aioclock/exceptions.py
+++ b/aioclock/exceptions.py
@@ -4,3 +4,7 @@ class BaseAioClockException(Exception):
 
 class TaskIdNotFound(BaseAioClockException):
     """Task not found in the AioClock app."""
+
+
+class TaskTimeoutError(BaseAioClockException, TimeoutError):
+    """A task took longer than its timeout"""

--- a/aioclock/group.py
+++ b/aioclock/group.py
@@ -38,8 +38,8 @@ class Group:
             limiter:
                 Anyio CapacityLimiter. capacity limiter to use to limit the total amount of threads running
                 Limiter that will be used to limit the number of tasks that are running at the same time.
-                If not provided, it will fallback to the default limiter set on Application level.
-                If no limiter is set on Application level, it will fallback to the default limiter set by AnyIO.
+                If not provided, it will fall back to the default limiter set on Application level.
+                If no limiter is set on Application level, it will fall back to the default limiter set by AnyIO.
 
         Example:
             ```python
@@ -118,7 +118,7 @@ class Group:
     async def _run(self):
         """
         Just for purpose of being able to run all task in group
-        Private method, should not be used outside of the library
+        Private method, should not be used outside the library
         """
         await asyncio.gather(
             *(task.run() for task in self._tasks),

--- a/aioclock/group.py
+++ b/aioclock/group.py
@@ -26,7 +26,7 @@ class Group:
         self,
         *,
         limiter: Optional[anyio.CapacityLimiter] = None,
-        timeout: float | None = None
+        timeout: Optional[float] = None
     ):
         """
         Group of tasks that will be run together.
@@ -86,7 +86,7 @@ class Group:
         self._limiter = limiter
         self._timeout = timeout
 
-    def task(self, *, trigger: BaseTrigger, timeout: float | None = None):
+    def task(self, *, trigger: BaseTrigger, timeout: Optional[float] = None):
         """
         Decorator to add a task to the group.
         If decorated function is sync, aioclock will run it in a thread pool executor, using AnyIO.

--- a/aioclock/task.py
+++ b/aioclock/task.py
@@ -10,7 +10,7 @@ These tasks keep running forever until the trigger's method `should_trigger` ret
 import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Optional
 from uuid import UUID, uuid4
 
 from aioclock.exceptions import TaskTimeoutError
@@ -38,7 +38,7 @@ class Task:
 
     trigger: BaseTrigger
 
-    timeout: float | None = None
+    timeout: Optional[float] = None
     id: UUID = field(default_factory=uuid4)
 
     async def run(self):

--- a/aioclock/task.py
+++ b/aioclock/task.py
@@ -1,6 +1,8 @@
 """
-Aioclock wrap your functions with a task object, and append the task to the list of tasks in the AioClock instance.
-After collecting all the tasks from decorated functions, aioclock serve them in order it has to be (startup, normal, shutdown).
+Aioclock wrap your functions with a task object,
+and append the task to the list of tasks in the AioClock instance.
+After collecting all the tasks from decorated functions,
+aioclock serve them in order it has to be (startup, normal, shutdown).
 
 These tasks keep running forever until the trigger's method `should_trigger` returns False.
 """
@@ -28,7 +30,7 @@ class Task:
         func: Callable[..., Awaitable[Any]]: Decorated function that will be run by AioClock.
         trigger: BaseTrigger: Trigger that will be used to run the function.
         id: UUID: Task ID that is unique for each task, and changes every time you run the aioclock app.
-            In future we might store task ID in a database, so that it always remains same.
+            In the future, we might store task ID in a database, so that it always remains same.
 
     """
 

--- a/aioclock/triggers.py
+++ b/aioclock/triggers.py
@@ -62,7 +62,7 @@ class BaseTrigger(BaseModel, ABC, Generic[TriggerTypeT]):
         1. An async function which is a task, is decorated with framework, and trigger is the arguement for the decorator
         2. `get_waiting_time_till_next_trigger` is called to get the time in seconds, after which the event should be triggered.
         3. If the time is not None, then it logs the time that is predicted for the event to be triggered.
-        4. `trigger_next` is called immidiately after that, which triggers the event.
+        4. `trigger_next` is called immediately after that, which triggers the event.
 
     You can create trigger by yourself, by inheriting from `BaseTrigger` class.
 
@@ -125,7 +125,7 @@ class BaseTrigger(BaseModel, ABC, Generic[TriggerTypeT]):
 
 
 class Forever(BaseTrigger[Literal[Triggers.FOREVER]]):
-    """A trigger that is always triggered imidiately.
+    """A trigger that is always triggered immediately.
 
     Example:
         ```python
@@ -191,7 +191,7 @@ class LoopController(BaseTrigger, ABC, Generic[TriggerTypeT]):
     max_loop_count: Union[PositiveInt, None] = None
 
     @model_validator(mode="after")
-    def validate_loop_controll(self):
+    def validate_loop_control(self):
         if "_current_loop_count" in self.model_fields_set:
             raise ValueError("_current_loop_count is a private attribute, should not be provided.")
         return self

--- a/examples/app.py
+++ b/examples/app.py
@@ -26,7 +26,7 @@ def sync_task_2(val: Annotated[str, Depends(dependency)]):
     return "3"
 
 
-print(sync_task_2("Aioclock won't color your functions! "))
+print(sync_task_2("Aioclock won't color your functions!"))
 
 
 @group.task(trigger=Every(seconds=2))

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -128,7 +128,7 @@ async def test_every():
 
 @pytest.mark.asyncio
 async def test_cron():
-    # it's dumb idea to test library, but I don't trust it 100%, and i might drop it in the future.
+    # it's dumb idea to test library, but I don't trust it 100%, and it might drop it in the future.
 
     trigger = Cron(cron="* * * * *", tz="UTC")
     val = await trigger.get_waiting_time_till_next_trigger(
@@ -161,7 +161,7 @@ async def test_cron():
     )
 
     with pytest.raises(ValueError):
-        trigger = Cron(cron="* * * * 65", tz="UTC")
+        Cron(cron="* * * * 65", tz="UTC")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What's new
## Groups
### Set a `timeout` for a group of tasks.
```python
group = Group(timeout=4)

@group.task(trigger=Every(...))
async def _(...):   # this task will fail every time it runs
    await asyncio.sleep(6)  
```

### set a `timeout` for each task
```python
group = Group(timeout=4)

@group.task(trigger=Every(...))  # this task has the group's timeout
async def _(...): ...

@group.task(trigger=Every(...), timeout=3)  # this task has its specific timeout
async def _(...): ...
```

## App
### set a `timeout` for each task
```python
app = AioClock()

@app.task(trigger=Every(...))  # this task does not have a timeout
async def _(...): ...

@app.task(trigger=Every(...), timeout=3)  # this task has its specific timeout
async def _(...): ...
```

## PS
I didn't know how to write tests for this feature, however all old tests are passed.